### PR TITLE
Added Defenders of Magic

### DIFF
--- a/index.html
+++ b/index.html
@@ -40,7 +40,7 @@
         <div>
           <ul>
         <li class="need">The Legend of Huma</li>
-        <li class="need">Stormblade</li>
+        <li class="have">Stormblade</li>
         <li class="have">Weasel's Luck</li>
       </ul>
         </div>
@@ -102,8 +102,7 @@
     <ul>
         <li class="have">Knights of the Crown</li>
         <li class="need">Maquesta Kar-Thon</li>
-        <li class="have">Knights of the Sword
-</li>
+        <li class="have">Knights of the Sword</li>
         <li class="need">Theros Ironfeld</li>
         <li class="need">Knights of the Rose</li>
         <li class="need">Lord Soth</li>
@@ -111,8 +110,20 @@
     </ul>
         </div>
     </article>
-<li>   Heroes: Stormblade, 3; </li>
-<li>Defending of the Magic: 2;</li>
+        <article>
+            <header>
+                <h3>Defenders of Magic</h3>
+            </header>
+        <div>
+    <ul>
+        <li class="need">Night of the Eye</li>
+        <li class="have">The Medusa Plague</li>
+        <li class="need">The Seventh Sentinel</li>
+    </ul>
+        </div>
+    </article>
+        <article>
+            <header>
 <li>Saga:  Tales, Dark Heart;</li>
 <li>   Dwarven Nations: 1; </li>
 <li>   Elven Nations: 1,2,3;</li>


### PR DESCRIPTION
I added the Heroes, Heroes II section, found we already had it, and then
updated the Heroes entry with the new book down the list. Deleted the
new entries, and created the Defenders of Magic entry. Which, on the
list is called Defending the Magic. I'm assuming it is the same thing.
